### PR TITLE
book support

### DIFF
--- a/control.lua
+++ b/control.lua
@@ -606,7 +606,8 @@ local function GetBlueprint(manager, signals1)
   local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
   local bp = inInv[1]
   local page = get_signal_from_set(knownsignals.blueprint_book,signals1)
-  if page > 0 then bp = inInv[2].get_inventory(defines.inventory.item_main)[page] end
+  --check if there actually is a blueprint book.
+  if page > 0 and inInv[2].is_blueprint_book then bp = inInv[2].get_inventory(defines.inventory.item_main)[page] end
   return bp
 end
 

--- a/control.lua
+++ b/control.lua
@@ -605,7 +605,7 @@ end
 local function GetBlueprint(manager, signals1)
   local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
   local bp = inInv[1]
-  local page = get_signal_form_set(knownsignals.blueprint_book,signals1)
+  local page = get_signal_from_set(knownsignals.blueprint_book,signals1)
   if page > 0 then bp = inInv[2].get_inventory(defines.inventory.item_main)[page] end
   return bp
 end

--- a/control.lua
+++ b/control.lua
@@ -595,11 +595,24 @@ local function EjectBlueprint(manager)
   inInv[1].clear()
 end
 
-local function DeployBlueprint(manager,signals1,signals2)
+local function EjectBlueprintBook(manager)
   local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
+  local outInv = manager.ent.get_inventory(defines.inventory.assembling_machine_output)
+  outInv[2].set_stack(inInv[2])
+  inInv[2].clear()
+end
 
-  -- confirm it's a blueprint and is setup and such...
+local function GetBlueprint(manager, signals1)
+  local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
   local bp = inInv[1]
+  local page = get_signal_form_set(knownsignals.blueprint-book,signals1)
+  if page > 0 then bp = inInv[2].get_inventory(defines.inventory.item_main)[page] end
+  return bp
+end
+
+
+local function DeployBlueprint(manager,signals1,signals2)
+  local bp = Getblueprint(manager,signals1)
   if bp.valid and bp.valid_for_read and bp.is_blueprint_setup() then
 
     local force_build = get_signal_from_set(knownsignals.F,signals1)==1
@@ -615,9 +628,7 @@ local function DeployBlueprint(manager,signals1,signals2)
 end
 
 local function CaptureBlueprint(manager,signals1,signals2)
-  local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
-  -- confirm it's a blueprint and is setup and such...
-  local bp = inInv[1]
+  local bp = Getblueprint(manager,signals1)
   if bp.valid and bp.valid_for_read then
     local capture_tiles = get_signal_from_set(knownsignals.T,signals1)==1
     local capture_entities = get_signal_from_set(knownsignals.E,signals1)==1
@@ -696,9 +707,7 @@ local function ConnectWire(manager,signals1,signals2,color,disconnect)
 end
 
 local function ReportBlueprintLabel(manager,signals1,signals2)
-  local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
-  -- confirm it's a blueprint and is setup and such...
-  local bp = inInv[1]
+  local bp = Getblueprint(manager,signals1)
   local outsignals = {}
   if bp.valid and bp.valid_for_read then
     if bp.label and remote.interfaces['signalstrings'] then
@@ -719,9 +728,7 @@ local function ReportBlueprintLabel(manager,signals1,signals2)
 end
 
 local function UpdateBlueprintLabel(manager,signals1,signals2)
-  local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
-  -- confirm it's a blueprint and is setup and such...
-  local bp = inInv[1]
+  local bp = Getblueprint(manager,signals1)
   local outsignals = {}
   if not (bp.valid and bp.valid_for_read and bp.is_blueprint_setup()) then
    return
@@ -748,9 +755,7 @@ local function UpdateBlueprintLabel(manager,signals1,signals2)
 end
 
 local function ReportBlueprintBoM(manager,signals1,signals2)
-  local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
-  -- confirm it's a blueprint and is setup and such...
-  local bp = inInv[1]
+  local bp = Getblueprint(manager,signals1)
   local outsignals = {}
   if bp.valid and bp.valid_for_read then
     -- BoM signals
@@ -892,10 +897,12 @@ local function onTickManager(manager)
     manager.clearcc2 = nil
     manager.cc2.get_or_create_control_behavior().parameters=nil
   end
+  
 
   local signals1 = manager.cc1.get_merged_signals()
   if signals1 then
     local signals2 = manager.cc2.get_merged_signals()
+    
 
     local bpsig = get_signal_from_set(knownsignals.blueprint,signals1)
     local bpfunc = bp_signal_funtions[bpsig] -- commands using blueprint item, indexed by command number
@@ -903,7 +910,9 @@ local function onTickManager(manager)
       bpfunc(manager,signals1,signals2)
     else
 
-      if get_signal_from_set(knownsignals.conbot,signals1) == 1 then
+      if get_signal_from_set(knownsignals.blueprint-book,signals1) == -1 then
+        EjectBlueprintBook(manager)
+      elseif get_signal_from_set(knownsignals.conbot,signals1) == 1 then
         -- check for conbot=1, build a thing
         ConstructionOrder(manager,signals1,signals2)
       elseif get_signal_from_set(knownsignals.logbot,signals1) == 1 then

--- a/control.lua
+++ b/control.lua
@@ -605,7 +605,7 @@ end
 local function GetBlueprint(manager, signals1)
   local inInv = manager.ent.get_inventory(defines.inventory.assembling_machine_input)
   local bp = inInv[1]
-  local page = get_signal_form_set(knownsignals.blueprint-book,signals1)
+  local page = get_signal_form_set(knownsignals.blueprint_book,signals1)
   if page > 0 then bp = inInv[2].get_inventory(defines.inventory.item_main)[page] end
   return bp
 end
@@ -910,7 +910,7 @@ local function onTickManager(manager)
       bpfunc(manager,signals1,signals2)
     else
 
-      if get_signal_from_set(knownsignals.blueprint-book,signals1) == -1 then
+      if get_signal_from_set(knownsignals.blueprint_book,signals1) == -1 then
         EjectBlueprintBook(manager)
       elseif get_signal_from_set(knownsignals.conbot,signals1) == 1 then
         -- check for conbot=1, build a thing

--- a/control.lua
+++ b/control.lua
@@ -612,7 +612,7 @@ end
 
 
 local function DeployBlueprint(manager,signals1,signals2)
-  local bp = Getblueprint(manager,signals1)
+  local bp = GetBlueprint(manager,signals1)
   if bp.valid and bp.valid_for_read and bp.is_blueprint_setup() then
 
     local force_build = get_signal_from_set(knownsignals.F,signals1)==1
@@ -628,7 +628,7 @@ local function DeployBlueprint(manager,signals1,signals2)
 end
 
 local function CaptureBlueprint(manager,signals1,signals2)
-  local bp = Getblueprint(manager,signals1)
+  local bp = GetBlueprint(manager,signals1)
   if bp.valid and bp.valid_for_read then
     local capture_tiles = get_signal_from_set(knownsignals.T,signals1)==1
     local capture_entities = get_signal_from_set(knownsignals.E,signals1)==1
@@ -707,7 +707,7 @@ local function ConnectWire(manager,signals1,signals2,color,disconnect)
 end
 
 local function ReportBlueprintLabel(manager,signals1,signals2)
-  local bp = Getblueprint(manager,signals1)
+  local bp = GetBlueprint(manager,signals1)
   local outsignals = {}
   if bp.valid and bp.valid_for_read then
     if bp.label and remote.interfaces['signalstrings'] then
@@ -728,7 +728,7 @@ local function ReportBlueprintLabel(manager,signals1,signals2)
 end
 
 local function UpdateBlueprintLabel(manager,signals1,signals2)
-  local bp = Getblueprint(manager,signals1)
+  local bp = GetBlueprint(manager,signals1)
   local outsignals = {}
   if not (bp.valid and bp.valid_for_read and bp.is_blueprint_setup()) then
    return
@@ -755,7 +755,7 @@ local function UpdateBlueprintLabel(manager,signals1,signals2)
 end
 
 local function ReportBlueprintBoM(manager,signals1,signals2)
-  local bp = Getblueprint(manager,signals1)
+  local bp = GetBlueprint(manager,signals1)
   local outsignals = {}
   if bp.valid and bp.valid_for_read then
     -- BoM signals

--- a/knownsignals.lua
+++ b/knownsignals.lua
@@ -42,7 +42,7 @@ return {
     info = {name="signal-info",type="virtual"},
   
     blueprint = {name="blueprint",type="item"},
-    blueprint-book = {name= "blueprint-book", type= "item"},
+    blueprint_book = {name= "blueprint-book", type= "item"},
     redprint = {name="deconstruction-planner",type="item"},
     conbot = {name="construction-robot",type="item"},
     logbot = {name="logistic-robot",type="item"},

--- a/knownsignals.lua
+++ b/knownsignals.lua
@@ -42,6 +42,7 @@ return {
     info = {name="signal-info",type="virtual"},
   
     blueprint = {name="blueprint",type="item"},
+    blueprint-book = {name= "blueprint-book", type= "item"},
     redprint = {name="deconstruction-planner",type="item"},
     conbot = {name="construction-robot",type="item"},
     logbot = {name="logistic-robot",type="item"},

--- a/prototypes/recipes.lua
+++ b/prototypes/recipes.lua
@@ -24,10 +24,14 @@ data:extend{
     category = "conman",
     ingredients =
     {
-      {"blueprint", 1}
+      {"blueprint", 1},
+      {"blueprint-book", 1}
     },
-    result = "blueprint",
-    result_count = 1,
+    results = 
+    {
+      {type="item", name="blueprint",amount =  1}, {type="item", name= "blueprint-book", amount = 1}
+    },
+	  main_product= "blueprint",
     icon = "__base__/graphics/icons/roboport.png",
     icon_size = 32,
   },


### PR DESCRIPTION
If blueprint book is > 0, it applies every function except eject to the blueprint at position blueprint book in the book. Added ejectblueprintBook for book =-1. 

It does not add empty blueprints or rename blueprints.

Edit: I did very brief testing and at the very least the deploy feature seems to work.